### PR TITLE
Update README.md – KittyCAD moved to Electron😌

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,7 +358,6 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [Happy](https://github.com/thewh1teagle/happy) - Control HappyLight compatible LED strip with ease.
 - [Imagefly](https://www.imagefly.dev/?ref=awesometauri) ![closed source] - Powerful offline image processing toolkit for Windows, Linux and macOS
 - [Jane Reader](https://janereader.com) ![closed source] - Modern and distraction-free epub reader.
-- [KittyCAD](https://github.com/KittyCAD/modeling-app) - Modern 3D mechanical/hardware design. Build 3D models with both code and WYSIWYG editors.
 - [KoS - Key on Screen](https://github.com/dubisdev/key-on-screen) - Show in your screen the keys you are pressing.
 - [Lanaya](https://github.com/ChurchTao/Lanaya) - Easy to use, cross-platform clipboard management.
 - [Lingo](https://github.com/thewh1teagle/lingo) - Translate offline in every language on every platform.


### PR DESCRIPTION
This PR is a deletion change in the [Utilities](https://github.com/tauri-apps/awesome-tauri?tab=readme-ov-file#utilities) section of the [Awesome Tauri](https://github.com/tauri-apps/awesome-tauri?tab=readme-ov-file#awesome-tauri) list.

[KittyCAD](https://github.com/KittyCAD/modeling-app) doesn't use Tauri anymore: https://github.com/KittyCAD/modeling-app/pull/3315/files

